### PR TITLE
Add dockerfile and instructions for how to use it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Build this container with (you can use docker instead of podman if you'd like):
+#
+# $ podman build . -t fyrtur-motor-board
+#
+# To build the firmware with the container image produced above, run:
+#
+# $ podman run --rm -it -v ${PWD}:/build:Z fyrtur-motor-board make -f STM32Make.make
+
+FROM debian:11-slim
+
+RUN apt-get update -y && apt-get install -y \
+    gcc-arm-none-eabi make \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)"
 # LDFLAGS
 #######################################
 # link script
-LDSCRIPT = STM32F030K6Tx_FLASH.ld
+LDSCRIPT = STM32F030K6TX_FLASH.ld
 
 # libraries
 LIBS = -lc -lm -lnosys 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,11 @@ The motor is connected with 4 wires (TX, RX, GND, VCC). TX and RX are UART lines
 **This software is provided "as is". Use with caution and at your own risk! (See LICENSE file for DISCLAIMER)**
 
 #### Software installation
-For compiling the sources, install [STM32CubeIDE](https://www.st.com/en/development-tools/stm32cubeide.html) (I used version 1.4.2).  UPDATE: Currently I'm using Visual Studio Code and the "STM32 for VSCode" plugin.
+
+The easiest way to build this firmware, if you have a podman/docker compatible container runtime available, is
+via the container definition available at [Dockerfile](./Dockerfile). See the `Dockerfile` for instructions on how to build and use the container image.
+
+You can also install [STM32CubeIDE](https://www.st.com/en/development-tools/stm32cubeide.html) (I used version 1.4.2) or Visual Studio Code with the "STM32 for VSCode" plugin.
 
 Alternatively you can use binaries found in bin/ folder.
 

--- a/STM32-for-VSCode.config.yaml
+++ b/STM32-for-VSCode.config.yaml
@@ -17,7 +17,7 @@ targetMCU: stm32f0x
 cpu: -mcpu=cortex-m0
 fpu: 
 floatAbi: 
-ldscript: STM32F030K6Tx_FLASH.ld # linker script
+ldscript: STM32F030K6TX_FLASH.ld # linker script
 
 # Compiler definitions. The -D prefix for the compiler will be automatically added.
 cDefinitions: 

--- a/STM32Make.make
+++ b/STM32Make.make
@@ -159,7 +159,7 @@ CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)"
 # LDFLAGS
 #######################################
 # link script
-LDSCRIPT = STM32F030K6Tx_FLASH.ld
+LDSCRIPT = STM32F030K6TX_FLASH.ld
 
 # libraries
 LIBS = -lc -lm -lnosys 

--- a/STM32Make.make
+++ b/STM32Make.make
@@ -81,8 +81,8 @@ startup_stm32f030x6.s
 PREFIX = arm-none-eabi-
 POSTFIX = "
 # The gcc compiler bin path can be either defined in make command via GCC_PATH variable (> make GCC_PATH=xxx)
-# either it can be added to the PATH environment variable.
-GCC_PATH="/opt/homebrew/bin
+# either it can be added to the PATH environment variable. Or it can be hardcoded here:
+#GCC_PATH="/opt/homebrew/bin
 ifdef GCC_PATH
 CXX = $(GCC_PATH)/$(PREFIX)g++$(POSTFIX)
 CC = $(GCC_PATH)/$(PREFIX)gcc$(POSTFIX)


### PR DESCRIPTION
Here I make the minimal amount of changes needed to make this project build in Linux (some of it borrowed from #15. Then I add a container definition file that makes it super easy to build the firmware in a Linux container if you are on either Linux or macOS. This solves the pain of trying to find an ARM C compiler for your own distro, and just works.